### PR TITLE
feat: add theme for query page

### DIFF
--- a/packages/studio-query/src/app/container.tsx
+++ b/packages/studio-query/src/app/container.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-
+import { theme } from 'antd';
+const { useToken } = theme;
 interface ContainerProps {
   sidebar: React.ReactNode;
   content: React.ReactNode;
@@ -14,6 +15,8 @@ const CollapsedWidth = 50;
 
 const Container: React.FunctionComponent<ContainerProps> = props => {
   const { sidebar, content, footer, collapse, displaySidebarPosition = 'left', enableAbsolutePosition } = props;
+  const { token } = useToken();
+
   const positionStyle: React.CSSProperties = enableAbsolutePosition
     ? {
         position: 'absolute',
@@ -29,8 +32,8 @@ const Container: React.FunctionComponent<ContainerProps> = props => {
         transition: 'all 0.3s ease',
         boxSizing: 'border-box',
         overflow: 'hidden',
-        borderLeft: displaySidebarPosition === 'left' ? 'none' : '1px solid #ddd',
-        borderRight: displaySidebarPosition === 'right' ? 'none' : '1px solid #ddd',
+        borderLeft: displaySidebarPosition === 'left' ? 'none' : `1px solid ${token.colorBorder}`,
+        borderRight: displaySidebarPosition === 'right' ? 'none' : `1px solid ${token.colorBorder}`,
         flexBasis: collapse ? `${CollapsedWidth}px` : `${SideWidth}px`,
         flexShrink: 0,
       }}
@@ -50,7 +53,7 @@ const Container: React.FunctionComponent<ContainerProps> = props => {
         display: 'flex',
         flexWrap: 'nowrap',
         overflow: 'hidden',
-        background: '#fff',
+        background: token.colorBgBase,
         ...positionStyle,
       }}
     >
@@ -69,8 +72,8 @@ const Container: React.FunctionComponent<ContainerProps> = props => {
             boxSizing: 'border-box',
             flex: 1,
             overflowY: 'scroll',
-            // background: '#fff',
-            background: '#f4f5f5',
+            //@ts-ignore
+            background: token.colorBgLayout,
             borderRadius: '12px',
           }}
           className="gs-content"
@@ -82,7 +85,7 @@ const Container: React.FunctionComponent<ContainerProps> = props => {
           style={{
             padding: '6px 6px',
             fontSize: '12px',
-            color: '#ddd',
+            color: `1px solid ${token.colorBorder}`,
           }}
         >
           {footer}

--- a/packages/studio-query/src/app/content/header.tsx
+++ b/packages/studio-query/src/app/content/header.tsx
@@ -1,17 +1,12 @@
-import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import {
-  InsertRowAboveOutlined,
-  OrderedListOutlined,
-  PlusOutlined,
-  PlayCircleOutlined,
-  PoweroffOutlined,
-} from '@ant-design/icons';
-import { Tooltip, Segmented, Button, Space, Select, Flex, Typography } from 'antd';
+import React, { useRef, useState } from 'react';
+import { InsertRowAboveOutlined, OrderedListOutlined, PlayCircleOutlined } from '@ant-design/icons';
+import { Tooltip, Segmented, Button, Space, Flex, Typography } from 'antd';
 import { localStorageVars } from '../context';
 import { useContext } from '../context';
 import CypherEditor from '../../cypher-editor';
 import { countLines } from '../utils';
 import { v4 as uuidv4 } from 'uuid';
+
 interface IHeaderProps {}
 
 const options = [
@@ -75,6 +70,7 @@ const Header: React.FunctionComponent<IHeaderProps> = props => {
     lineCount: 1,
     clear: false,
   });
+
   const { globalScript, autoRun, language, graphName } = store;
 
   const handleChange = value => {};

--- a/packages/studio-query/src/app/content/index.tsx
+++ b/packages/studio-query/src/app/content/index.tsx
@@ -1,7 +1,7 @@
 import React, { useState, memo } from 'react';
 import Statement from '../../statement';
 import Header from './header';
-import { Segmented } from 'antd';
+import { Segmented, theme } from 'antd';
 import { useContext } from '../context';
 import type { IStatement, IStudioQueryProps } from '../context';
 import { PlayCircleOutlined } from '@ant-design/icons';
@@ -11,12 +11,14 @@ interface IContentProps {
   queryGraphData: IStudioQueryProps['queryGraphData'];
   enableImmediateQuery: boolean;
 }
+const { useToken } = theme;
 
 const Content: React.FunctionComponent<IContentProps> = props => {
   const { createStatements, queryGraphData, enableImmediateQuery } = props;
   const { store, updateStore } = useContext();
   const { activeId, mode, statements, savedStatements, schemaData, graphName, language } = store;
   const savedIds = savedStatements.map(item => item.id);
+  const { token } = useToken();
 
   const statementStyles =
     mode === 'tabs'
@@ -75,7 +77,14 @@ const Content: React.FunctionComponent<IContentProps> = props => {
         height: '100%',
       }}
     >
-      <div style={{ minHeight: '50px', background: '#fff', padding: '0px 12px', borderBottom: '1px solid #ddd' }}>
+      <div
+        style={{
+          minHeight: '50px',
+          background: token.colorBgBase,
+          padding: '0px 12px',
+          borderBottom: `1px solid ${token.colorBorder}`,
+        }}
+      >
         <Header />
         {mode === 'tabs' && queryOptions.length !== 0 && (
           <div style={{ padding: '8px 0px' }}>

--- a/packages/studio-query/src/app/provider.tsx
+++ b/packages/studio-query/src/app/provider.tsx
@@ -8,21 +8,24 @@ export default function Provider(props) {
   const { primaryColor, mode, inputNumber = '6px' } = theme;
   //@ts-ignore
   const messages = locales[locale];
+  const isLightMode = mode === 'defaultAlgorithm';
   return (
     <IntlProvider messages={messages} locale={locale}>
       <ConfigProvider
         theme={{
           // 1. 单独使用暗色算法
-          algorithm: mode === 'defaultAlgorithm' ? AntdTheme.defaultAlgorithm : AntdTheme.darkAlgorithm,
+          algorithm: isLightMode ? AntdTheme.defaultAlgorithm : AntdTheme.darkAlgorithm,
           components: {
             Table: {
-              headerBg: mode === 'defaultAlgorithm' ? '#fff' : '#161616',
-              headerColor: mode === 'defaultAlgorithm' ? 'rgba(0, 0, 0, 0.45)' : '#DBDBDB',
-              headerSplitColor: mode === 'defaultAlgorithm' ? '#fff' : '#161616',
+              headerBg: isLightMode ? '#fff' : '#161616',
+              headerColor: isLightMode ? 'rgba(0, 0, 0, 0.45)' : '#DBDBDB',
+              headerSplitColor: isLightMode ? '#fff' : '#161616',
             },
           },
           token: {
             colorPrimary: primaryColor,
+            /** custom */
+            colorBgLayout: isLightMode ? '#f5f7f9' : '#161616',
           },
         }}
       >

--- a/packages/studio-query/src/app/sidebar/index.tsx
+++ b/packages/studio-query/src/app/sidebar/index.tsx
@@ -24,44 +24,6 @@ interface SidebarProps {
   logo?: React.ReactNode;
 }
 
-const styles: Record<string, React.CSSProperties> = {
-  container: {
-    display: 'flex',
-    flexDirection: 'row',
-    height: '100%',
-  },
-  header: {
-    height: '50px',
-    lineHeight: '50px',
-    width: '100%',
-    transition: 'width ease 0.3s',
-    borderBottom: '1px solid #ddd',
-    overflow: 'hidden',
-  },
-  ul: {
-    flexBasis: '50px',
-    width: '50px',
-    height: '100%',
-    borderRight: '1px solid #ddd',
-    margin: '0px',
-    paddingInlineStart: '0px',
-    flexShrink: 0,
-  },
-  li: {
-    display: 'flex',
-    flexDirection: 'column',
-    width: '100%',
-    // height: '34px',
-    margin: '12px 0px',
-    cursor: 'pointer',
-    listStyle: 'none',
-    justifyContent: 'center',
-    alignItems: 'center',
-    boxSizing: 'border-box',
-  },
-  content: {},
-};
-
 const collapsedWidth = 50;
 const width = 300;
 const Sidebar: React.FunctionComponent<SidebarProps> = props => {
@@ -72,7 +34,43 @@ const Sidebar: React.FunctionComponent<SidebarProps> = props => {
   const activeOption = options.find(item => {
     return item.id === nav;
   });
-  console.log('token.colorBgBlur', token.colorBgBlur, token);
+
+  const styles: Record<string, React.CSSProperties> = {
+    container: {
+      display: 'flex',
+      flexDirection: 'row',
+      height: '100%',
+    },
+    header: {
+      height: '50px',
+      lineHeight: '50px',
+      width: '100%',
+      transition: 'width ease 0.3s',
+      borderBottom: `1px solid ${token.colorBorder}`,
+      overflow: 'hidden',
+    },
+    ul: {
+      flexBasis: '50px',
+      width: '50px',
+      height: '100%',
+      borderRight: `1px solid ${token.colorBorder}`,
+      margin: '0px',
+      paddingInlineStart: '0px',
+      flexShrink: 0,
+    },
+    li: {
+      display: 'flex',
+      flexDirection: 'column',
+      width: '100%',
+      margin: '12px 0px',
+      cursor: 'pointer',
+      listStyle: 'none',
+      justifyContent: 'center',
+      alignItems: 'center',
+      boxSizing: 'border-box',
+    },
+    content: {},
+  };
   return (
     <div
       style={{

--- a/packages/studio-query/src/app/sidebar/statement-list/index.tsx
+++ b/packages/studio-query/src/app/sidebar/statement-list/index.tsx
@@ -88,7 +88,7 @@ const List = props => {
 
             <pre
               style={{
-                background: '#f4f5f5',
+                background: token.colorBgLayout,
                 overflow: 'hidden',
                 textWrap: 'pretty',
                 padding: '6px 14px',

--- a/packages/studio-query/src/cypher-editor/index.tsx
+++ b/packages/studio-query/src/cypher-editor/index.tsx
@@ -66,15 +66,8 @@ const Editor = forwardRef<any, any>((props, editorRef) => {
   console.log('language', language, THEMES[language], LANGUAGE[language]);
   React.useEffect(() => {
     MonacoEnvironment.loadModule(async (container: { load: (arg0: Syringe.Module) => void }) => {
-      // const dsl = await import('@difizen/cofine-language-cypher');
       container.load(cypherLanguage);
       container.load(gremlinLanguage);
-      // if (language === 'cypher') {
-      //   container.load(cypherLanguage);
-      // }
-      // if (language === 'gremlin') {
-      //   container.load(gremlinLanguage);
-      // }
     });
     MonacoEnvironment.init().then(async () => {
       console.log('init....', language);
@@ -82,11 +75,14 @@ const Editor = forwardRef<any, any>((props, editorRef) => {
         if (countLines(value) <= maxRows) {
           editorRef.current.style.height = countLines(value) * 20 + 'px';
         }
+        //@TODO hard code
+        const isDark = JSON.parse(localStorage.getItem('GS_STUDIO_themeColor') || '') === 'darkAlgorithm';
+
         const editorProvider = MonacoEnvironment.container.get<EditorProvider>(EditorProvider);
         const editor = editorProvider.create(editorRef.current, {
           language: LANGUAGE[language],
           value,
-          theme: THEMES[language],
+          theme: isDark ? 'darkTheme' : THEMES[language],
           suggestLineHeight: 20,
           suggestLineHeight: 20,
           automaticLayout: true,
@@ -110,6 +106,7 @@ const Editor = forwardRef<any, any>((props, editorRef) => {
           scrollBeyondLastLine: false, // 不允许在内容的下方滚动
           scrollBeyondLastColumn: false, // 不允许在内容的右侧滚动
         });
+
         editorRef.current.codeEditor = codeEditor = editor.codeEditor;
         if (onInit) {
           onInit(editorRef.current.codeEditor);

--- a/packages/studio-query/src/graph/index.tsx
+++ b/packages/studio-query/src/graph/index.tsx
@@ -3,6 +3,7 @@ import Graphin, { GraphinData } from '@antv/graphin';
 import Panel from './panel';
 import { processData, calcOverview, storage, getConfig } from './utils';
 import type { ISchema } from './typing';
+import { theme } from 'antd';
 
 interface GraphViewProps {
   data: GraphinData;
@@ -18,6 +19,7 @@ const GraphView: React.FunctionComponent<GraphViewProps> = props => {
       configMap,
     };
   });
+  const { token } = theme.useToken();
 
   const { configMap } = state;
   const newData = processData(data, configMap);
@@ -42,7 +44,7 @@ const GraphView: React.FunctionComponent<GraphViewProps> = props => {
           type: 'concentric',
         },
       }}
-      style={{ height: '480px', minHeight: '480px', background: '#f4f5f5' }}
+      style={{ height: '480px', minHeight: '480px', background: token.colorBgLayout }}
     >
       {/** @ts-ignore */}
       <Panel overview={overview} onChange={onChange}></Panel>

--- a/packages/studio-query/src/statement/index.tsx
+++ b/packages/studio-query/src/statement/index.tsx
@@ -103,7 +103,7 @@ const Statement: React.FunctionComponent<IStatementProps> = props => {
         padding: '8px 16px',
         borderRadius: '8px',
         ...borderStyle,
-        background: '#fff',
+        background: token.colorBgBase,
       }}
     >
       <Editor


### PR DESCRIPTION
- light
![image](https://github.com/GraphScope/portal/assets/10703060/56c66179-7d5f-481c-9edc-b6751bef1b1b)
- dark：just need the editor's theme switch
![image](https://github.com/GraphScope/portal/assets/10703060/260e82c5-ec3a-4383-a809-e43f381e2cef)

