### PR TITLE
fix 🐛: cannot open draw pattern model

### DIFF
--- a/packages/studio-draw-pattern/src/components/DrawPattern.tsx
+++ b/packages/studio-draw-pattern/src/components/DrawPattern.tsx
@@ -65,12 +65,11 @@ export const DrawPattern: React.FC<DrawPatternProps> = props => {
             <QuickStart />
           </div>
         }
-        children={
-          <div id="canvas-wrapper" style={{ height: '100%', width: '100%', backgroundColor: '#E6F4FF' }}>
-            <Canvas />
-          </div>
-        }
-      />
+      >
+        <div id="canvas-wrapper" style={{ height: '100%', width: '100%', backgroundColor: '#E6F4FF' }}>
+          <Canvas />
+        </div>
+      </Section>
     </DrawPatternContext.Provider>
   );
 };

--- a/packages/studio-draw-pattern/src/components/QuickStart/Preview.tsx
+++ b/packages/studio-draw-pattern/src/components/QuickStart/Preview.tsx
@@ -38,23 +38,26 @@ export const Preview = () => {
     return newNodes;
   }, [previewGraph]);
 
+  console.log('更新后的节点', JSON.parse(JSON.stringify(updatePositionNode)));
+
   return (
     <div
       style={{
         borderRadius: '8px',
         border: '1px solid #E3E3E3',
-        height: '30%',
+        height: '50%',
         padding: '0.8rem',
         backgroundColor: '#F9F9F9',
         display: 'flex',
         flexDirection: 'column',
         gap: '0.6rem',
-        flexBasis: '30%',
+        flexBasis: '50%',
         marginTop: '1rem',
+        overflow: 'hidden',
       }}
     >
       <span style={{ fontSize: '1rem' }}>Model Preview</span>
-      <div style={{ flexGrow: '1', backgroundColor: 'white' }}>
+      <div style={{ backgroundColor: 'white', height: '100%', flexGrow: '1' }}>
         <Graph
           isControlButton={false}
           isMiniMap={false}

--- a/packages/studio-draw-pattern/src/components/QuickStart/index.tsx
+++ b/packages/studio-draw-pattern/src/components/QuickStart/index.tsx
@@ -134,7 +134,7 @@ export const QuickStart = () => {
       }}
     >
       <Preview />
-      <div id="items-wrapper" style={{ display: 'flex', flexDirection: 'column', height: '70%', gap: '0.3rem' }}>
+      <div id="items-wrapper" style={{ display: 'flex', flexDirection: 'column', height: '50%', gap: '0.3rem' }}>
         <span style={{ fontSize: '1rem' }}>
           <RocketOutlined />
           快速开始

--- a/packages/studio-draw-pattern/src/utils/index.ts
+++ b/packages/studio-draw-pattern/src/utils/index.ts
@@ -22,16 +22,19 @@ export function getSequentialLetter(): () => string {
 export const updateNodePositions = (nodes: ISchemaNode[]): ISchemaNode[] => {
   const updatedNodes: ISchemaNode[] = []; // 初始化一个新的数组
 
-  nodes.forEach(node => {
-    let { x, y } = node.position;
+  nodes.forEach((node, index) => {
+    let { x, y } = node.position ?? { x: Math.random() * 200, y: Math.random() * 200 };
 
     const spacing = 200; // 节点之间的最小间隔
+
+    console.log(node.id);
 
     while (
       updatedNodes.some(
         n => n.id !== node.id && Math.abs(n.position.x - x) < spacing && Math.abs(n.position.y - y) < spacing,
       )
     ) {
+      console.log('collision');
       x += spacing; // 向右移动
       // 如果向右移动之后仍然有重叠，尝试向下移动
       if (
@@ -44,7 +47,7 @@ export const updateNodePositions = (nodes: ISchemaNode[]): ISchemaNode[] => {
       }
     }
 
-    updatedNodes.push({ ...node, position: { x, y } }); // 将更新后的节点添加到数组
+    updatedNodes.push({ ...node, position: { x, y }, width: 100, height: 100 }); // 将更新后的节点添加到数组
   });
 
   return updatedNodes;

--- a/packages/studio-query/src/components/draw-pattern-modal/index.tsx
+++ b/packages/studio-query/src/components/draw-pattern-modal/index.tsx
@@ -1,7 +1,7 @@
 import { SignatureOutlined } from '@ant-design/icons';
 import { DrawPattern, DrawPatternValue, GraphProps } from '@graphscope/studio-draw-pattern';
 import { Button, Modal, Tooltip } from 'antd';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { useContext } from '../../app/context';
 
 export interface DrawPatternModalProps {
@@ -10,12 +10,12 @@ export interface DrawPatternModalProps {
 }
 
 export const DrawPatternModal: React.FC<DrawPatternModalProps> = ({ previewSchema, onClick }) => {
-  const [visible, setVisiable] = useState<boolean>(false);
+  const [visible, setVisible] = useState<boolean>(false);
   const { updateStore, store } = useContext();
   const { schemaData, language } = store;
 
   const handleClick = useCallback((value: DrawPatternValue) => {
-    setVisiable(false);
+    setVisible(false);
     const script = [value.MATCHs, value.WHEREs, value.RETURNs].join('\n');
     updateStore(draft => {
       draft.globalScript = script;
@@ -39,7 +39,7 @@ export const DrawPatternModal: React.FC<DrawPatternModalProps> = ({ previewSchem
       <Tooltip title={'快速绘制语句'} placement="right">
         <Button
           onClick={() => {
-            setVisiable(true);
+            setVisible(true);
           }}
           type="text"
           icon={<SignatureOutlined />}
@@ -49,8 +49,8 @@ export const DrawPatternModal: React.FC<DrawPatternModalProps> = ({ previewSchem
         title=""
         centered
         open={visible}
-        onOk={() => setVisiable(false)}
-        onCancel={() => setVisiable(false)}
+        onOk={() => setVisible(false)}
+        onCancel={() => setVisible(false)}
         width={'90%'}
         footer={null}
       >


### PR DESCRIPTION
# fix 🐛: cannot open draw pattern model
Fixed the issue that caused the module to crash due to changes in the data structure of preview nodes and edges.
![image](https://github.com/user-attachments/assets/db6b7cab-8ea2-4a7c-b7a1-1ef4827c0b0b)
