### PR TITLE
bug(graphy): Fix issue of unable to fetch from arxiv when title mis-matched

### DIFF
--- a/python/graphy/apps/paper_reading/paper_reading_nodes.py
+++ b/python/graphy/apps/paper_reading/paper_reading_nodes.py
@@ -13,6 +13,7 @@ from config import (
 from extractor import PaperExtractor
 from db import PersistentStore
 from utils.profiler import profiler
+from utils.cryptography import id_generator
 
 from langchain_core.pydantic_v1 import BaseModel, Field, create_model
 from langchain_core.language_models.llms import BaseLLM
@@ -45,7 +46,7 @@ def process_id(base_name: str) -> str:
 
     # Ensure it has at least 3 characters
     if len(id_name) < 3:
-        id_name = f"{hash(base_name)}_{id_name}"
+        id_name = f"{id_generator(base_name)}_{id_name}"
 
     return id_name
 

--- a/python/graphy/graph/nodes/pdf_extract_node.py
+++ b/python/graphy/graph/nodes/pdf_extract_node.py
@@ -1,5 +1,6 @@
 from .base_node import BaseNode, DataGenerator
 from utils import Paper, ArxivFetcher, ScholarFetcher
+from utils.profiler import profiler
 from config import (
     WF_STATE_EXTRACTOR_KEY,
     WF_STATE_MEMORY_KEY,
@@ -7,12 +8,10 @@ from config import (
 )
 
 from langchain_core.embeddings import Embeddings
-
 from typing import Any, Dict
-import logging
-from utils.profiler import profiler
-import time
+
 import os
+import logging
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +64,7 @@ class PDFExtractNode(BaseNode):
             if self.arxiv_fetch_paper:
                 paper_title = paper_metadata.get("title", "")
                 if len(paper_title) > 0:
-                    result = self.arxiv_fetcher.fetch_paper(paper_title, 5)
+                    result = self.arxiv_fetcher.fetch_paper(paper_title, 3)
                     if result:
                         paper_metadata.update(result)
 
@@ -77,11 +76,11 @@ class PDFExtractNode(BaseNode):
             if vectordb.is_db_valid() and vectordb.is_db_empty():
                 docs = pdf_extractor.extract_all()
                 pdf_paper_references = list(pdf_extractor.linked_contents)
-                logger.info("========= START TO INIT MEMORY ======")
+                logger.debug("========= START TO INIT MEMORY ======")
                 vectordb.init_memory_parallel(
                     docs, ["page_index", "section", "part_index"]
                 )
-                logger.info(
+                logger.debug(
                     f"========= FINISH TO INIT MEMORY {pdf_extractor.file_path} ======"
                 )
             else:

--- a/python/graphy/requirements.txt
+++ b/python/graphy/requirements.txt
@@ -38,5 +38,6 @@ torch==2.3.0
 transformers==4.41
 webdriver-manager>=4.0
 Werkzeug>=3.0.3
+wordninja>=2.0.0
 socksio>=1.0.0
 

--- a/python/graphy/utils/arxiv_fetcher.py
+++ b/python/graphy/utils/arxiv_fetcher.py
@@ -1,4 +1,6 @@
 from config import WF_DOWNLOADS_DIR
+from .bib_search import BibSearchArxiv
+
 from typing import List, Dict, Any
 
 import concurrent.futures
@@ -10,11 +12,39 @@ import logging
 import time
 import unicodedata
 import traceback
+import wordninja
 
-from .bib_search import BibSearchArxiv, BibSearchGoogleScholar
-from requests.exceptions import ProxyError, ConnectionError, RequestException
 
 logger = logging.getLogger(__name__)
+
+
+def prepare_arxiv_queries(original_query: str) -> Dict[str, str]:
+    # Normalize input to NFKC form and strip extra spaces
+    original_query = unicodedata.normalize("NFKC", original_query).strip()
+
+    # Generate original title query (ti:query)
+    original_title_query = f"ti:{original_query}"
+
+    # Clean up the query by replacing certain characters with spaces
+    cleaned_query = re.sub(r"[-_.:\[\]\\]", " ", original_query)
+
+    cleaned_title_query = f"ti:{cleaned_query}"
+
+    # Use wordninja to split the cleaned query into separate words
+    # Create new query with spaces between the words
+    refined_query = " ".join(wordninja.split(cleaned_query))
+
+    # Generate the title query for the cleaned, split query (ti:new_query)
+    refined_title_query = f"ti:{refined_query}"
+
+    # Return all generated queries as a list
+    return {
+        "cleaned_title": cleaned_title_query,
+        "original_title": original_title_query,
+        "refined_title": refined_title_query,
+        "cleaned": cleaned_query,
+        "original": original_query,
+    }
 
 
 class ResultFormer:
@@ -118,17 +148,10 @@ class ArxivFetcher:
         best_match = None
         added_query = set()
         for new_name in new_names:
-            # replace - with space to improve search results
-
-            original_query = new_name
-            original_title_query = f"ti:{original_query}"
-            query = re.sub(r"[-_.:\[\]\\]", " ", new_name).strip()
-            new_query = re.sub(r"[-_.:\[\]\\]", " ", new_name).strip()
-            title_query = f"ti:{new_query}"
-            queries = [original_title_query, original_query, title_query, query]
-
+            # replace special characters with space to improve search results
             found_result = False
-            for query in queries:
+            queries = prepare_arxiv_queries(new_name)
+            for opt, query in queries.items():
                 if query in added_query:
                     continue
                 else:
@@ -143,14 +166,13 @@ class ArxivFetcher:
                 similarity = 0.0
 
                 if search is not None:
-                    found_result = True
                     try:
                         for paper in self.client.results(search):
                             similarity = difflib.SequenceMatcher(
                                 None, new_name.lower(), paper.title.lower()
                             ).ratio()
                             logger.debug(
-                                f"Compared with: {new_name}, Found paper: {paper.title} with similarity {similarity}"
+                                f"With {opt} query : {query}, Found paper: {paper.title} with similarity {similarity}"
                             )
                             if similarity > highest_similarity:
                                 highest_similarity = similarity
@@ -161,9 +183,7 @@ class ArxivFetcher:
                         traceback.print_exc()
 
                 if highest_similarity > 0.9:
-                    # print(f"found {query}")
                     break
-                # logger.warning(f"Not Found: {query}")
 
             if highest_similarity > 0.9:
                 break
@@ -177,8 +197,6 @@ class ArxivFetcher:
 
     def download_paper(self, name: str, max_results):
         logger.info(f"Searching for paper: {name}")
-
-        name = unicodedata.normalize("NFKC", name)
 
         highest_similarity, best_match = self.find_paper_from_arxiv(name, max_results)
 
@@ -207,7 +225,6 @@ class ArxivFetcher:
         :param name: The name (query) of the paper to fetch.
         :return: A string describing the result of the fetch operation, or None if no paper is found.
         """
-
         logger.info(f"Searching for paper: {name}")
 
         highest_similarity, best_match = self.find_paper_from_arxiv(name, max_results)


### PR DESCRIPTION
Now when the paper's title is something like: Uniﬁed Language Model Pre-training forNatural Language Understanding and Generation, it can not be fetched from arxiv correctly. The reason is that there should be a space between "forNatural" in the above title. The pr fix this issue by introducing wordninja to break words that should have a space in between. 