### PR TITLE
use customized playwright-mcp

### DIFF
--- a/infra/sandbox/images/mix/Dockerfile
+++ b/infra/sandbox/images/mix/Dockerfile
@@ -32,7 +32,7 @@ WORKDIR ${PLAYWRIGHT_HOME}
 
 # Install Playwright dependencies and Chromium
 RUN npm init -y \
-    && npm install @playwright/mcp --save \
+    && npm install @ai-spider/playwright-mcp@0.0.2 --save \
     && npx playwright-core install-deps chromium \
     && npx playwright-core install --no-shell chromium \
     && npm cache clean --force \
@@ -44,7 +44,7 @@ RUN mkdir -p /opt/playwright-mcp/bin \
 #!/bin/sh
 if [ "$1" = "serve" ]; then
 cd "${PLAYWRIGHT_HOME}"
-exec npx @playwright/mcp \
+exec npx @ai-spider/playwright-mcp@0.0.2 \
 --headless \
 --browser chromium \
 --port 3000 \


### PR DESCRIPTION
This pull request updates the `Dockerfile` for the sandbox environment to use a new version of the Playwright MCP package. The changes ensure compatibility with the updated package and improve dependency management.

Dependency updates:

* [`infra/sandbox/images/mix/Dockerfile`](diffhunk://#diff-525e3e825a7d6ab0172275004c139099fb43e517d2787b7f822fea1087f9af14L35-R35): Updated the `npm install` command to use `@ai-spider/playwright-mcp@0.0.2` instead of `@playwright/mcp`. This change aligns the sandbox environment with the new package version.
* [`infra/sandbox/images/mix/Dockerfile`](diffhunk://#diff-525e3e825a7d6ab0172275004c139099fb43e517d2787b7f822fea1087f9af14L47-R47): Modified the `exec` command in the shell script to use `@ai-spider/playwright-mcp@0.0.2` for running Playwright MCP in headless mode.